### PR TITLE
Update

### DIFF
--- a/PropertyExplorerTest/Controls/InCanvasMovingBehavior.cs
+++ b/PropertyExplorerTest/Controls/InCanvasMovingBehavior.cs
@@ -9,6 +9,50 @@ namespace PropertyExplorerTest.Behaviors
     public class InCanvasMovingBehavior : DependencyObject
     {
 
+        #region AttachedProperty 일명 AP 사용법
+        /*
+         *  DependencyProperty RegisterAttached용 설정 방법 예시
+
+        public static readonly DependencyProperty MouseMoveProperty =
+            DependencyProperty.RegisterAttached(
+                name: "MouseMove", 
+                propertyType: typeof(int), 
+                ownerType: typeof(InCanvasMovingBehavior),
+                defaultMetadata: new FrameworkPropertyMetadata(false, CaptureFromContianerCallback)
+            );
+
+        public int MouseMove
+        {
+            get { return (int)GetValue(MouseMoveProperty); }
+            set { SetValue(MouseMoveProperty, value); }
+        }
+        하기 두 메소드는 상기 public int MouseMove의 메소드와
+        같은 의미를 한다. 보통 DependencyPropery.Register로는 
+        여기까지가 맞는것 같은데 DependencyProperty.RegisterAttached 
+        이기 때문에 아래와 같은 메소드를 사용하는지 정확하진 않다.
+
+        public static int GetMouseMove(DependencyObject obj)
+        {
+            return (int)obj.GetValue(MouseMoveProperty);
+        }
+
+        public static void SetMouseMove(DependencyObject obj, int vaule)
+        {
+            obj.SetValue(MouseMoveProperty, vaule);
+        }
+
+        */
+
+        #endregion
+
+        
+
+        #region Attached Property 등록 Capture, Panning, X, Y
+        /// <summary>
+        /// DependencyProperty 등록을 통한 Xaml접근이 가능해진다.
+        /// 정확하게 사용할 수 있는 컨트롤에 적용해야(같은 속성이나 타입이 있는 컨트롤) 
+        /// 정상동작하는것은 당연한 얘기 겠지만...
+        /// </summary>
         public static readonly DependencyProperty CapturedProperty = DependencyProperty.RegisterAttached
         (
             name: "Captured",
@@ -17,10 +61,15 @@ namespace PropertyExplorerTest.Behaviors
             defaultMetadata: new FrameworkPropertyMetadata(false, CaptureFromContianerCallback)
         );
 
+        /// <summary>
+        /// CapturedProperty 용 Callback
+        /// </summary>
+        /// <param name="d">ViewModel이 넘어올 것이고,</param>
+        /// <param name="e">New Selection이 있는 지 없는 지, NewValue로 볼 것</param>
         private static void CaptureFromContianerCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (!(d is FrameworkElement element))
-            { 
+            {
                 return;
             }
 
@@ -28,23 +77,34 @@ namespace PropertyExplorerTest.Behaviors
             if (isCaptured)
             {
                 element.CaptureMouse();
-            }            
+            }
         }
 
+        /// <summary>
+        /// get { return (bool)GetValue(CaputreProperty);}
+        /// 같은 의미이다.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public static bool GetCaptured(DependencyObject obj)
         {
             return (bool)obj.GetValue(CapturedProperty);
         }
-
+        /// <summary>
+        /// set { SetValue(CapturedProperty, value); }
+        /// 같은 의미이다.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="value"></param>
         public static void SetCaptured(DependencyObject obj, bool value)
         {
             obj.SetValue(CapturedProperty, value);
         }
 
 
-
-
-
+        /// <summary>
+        /// PanningTargetProperty AP 등록
+        /// </summary>
         public static readonly DependencyProperty PanningTargetProperty = DependencyProperty.RegisterAttached
         (
             name: "PanningTarget",
@@ -53,6 +113,11 @@ namespace PropertyExplorerTest.Behaviors
             defaultMetadata: new FrameworkPropertyMetadata(null, PanningTargetPropertyChanged)
         );
 
+        /// <summary>
+        /// PanningTargetProperty의 Callback
+        /// </summary>
+        /// <param name="d"></param>
+        /// <param name="e"></param>
         private static void PanningTargetPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (!(e.NewValue is FrameworkElement element))
@@ -64,16 +129,29 @@ namespace PropertyExplorerTest.Behaviors
             var infra = new PanningStructure(element);
         }
 
+        /// <summary>
+        /// Getter for Panning
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public static FrameworkElement GetPanningTarget(DependencyObject obj)
         {
             return (FrameworkElement)obj.GetValue(PanningTargetProperty);
         }
 
+        /// <summary>
+        /// Setter for Panning
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="value"></param>
         public static void SetPanningTarget(DependencyObject obj, object value)
         {
             obj.SetValue(PanningTargetProperty, value);
         }
 
+        /// <summary>
+        /// XProperty AP 등록
+        /// </summary>
         public static readonly DependencyProperty XProperty = DependencyProperty.RegisterAttached
         (
             name: "X",
@@ -82,20 +160,36 @@ namespace PropertyExplorerTest.Behaviors
             defaultMetadata: new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, PositinChangedCallback)
         );
 
+        /// <summary>
+        /// XProperty CallbackFunction은 할게 없나보네...
+        /// </summary>
+        /// <param name="d"></param>
+        /// <param name="e"></param>
         private static void PositinChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
         }
-
+        /// <summary>
+        /// Getter for XProperty
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public static double GetX(DependencyObject obj)
         {
             return (double)obj.GetValue(XProperty);
         }
-
+        /// <summary>
+        /// Setter for XProperty
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="value"></param>
         public static void SetX(DependencyObject obj, object value)
         {
             obj.SetValue(XProperty, value);
         }
 
+        /// <summary>
+        /// YProperty AP 등록
+        /// </summary>
         public static readonly DependencyProperty YProperty = DependencyProperty.RegisterAttached
         (
             name: "Y",
@@ -104,11 +198,21 @@ namespace PropertyExplorerTest.Behaviors
             defaultMetadata: new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, PositinChangedCallback)
         );
 
+        /// <summary>
+        /// Getter for YProperty
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public static double GetY(DependencyObject obj)
         {
             return (double)obj.GetValue(YProperty);
         }
 
+        /// <summary>
+        /// Setter for YProperty
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="value"></param>
         public static void SetY(DependencyObject obj, object value)
         {
             obj.SetValue(YProperty, value);
@@ -116,6 +220,35 @@ namespace PropertyExplorerTest.Behaviors
 
 
 
+        public static int GetZLevel(DependencyObject obj)
+        {
+            return (int)obj.GetValue(ZLevelProperty);
+        }
+
+        public static void SetZLevel(DependencyObject obj, int value)
+        {
+            obj.SetValue(ZLevelProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for Z.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ZLevelProperty = DependencyProperty.RegisterAttached
+        (
+            name: "ZLevel",
+            propertyType: typeof(int),
+            ownerType: typeof(InCanvasMovingBehavior),
+            defaultMetadata: new FrameworkPropertyMetadata((int)100, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, PositinChangedCallback)
+        );
+
+
+
+        #endregion
+
+        /// <summary>
+        /// 엄마 찾아 삼만리....
+        /// </summary>
+        /// <typeparam name="T">원하는 엄마</typeparam>
+        /// <param name="child">나는 그의 자식</param>
+        /// <returns></returns>
         public static T FindParentOfType<T>(DependencyObject child) where T : DependencyObject
         {
             DependencyObject parentDepObj = child;
@@ -132,6 +265,12 @@ namespace PropertyExplorerTest.Behaviors
         public class PanningStructure : DependencyObject
         {
             private bool _isCaptured;
+
+            private bool _isZTop = false;
+
+            private int _savedZLevel;
+
+            private const int MAX_LEVEL = 255;
 
             /// <summary>
             /// 마우스 다운 위치로부터 오브젝트의 좌상단을 보정하기 위한 포인트.
@@ -163,7 +302,24 @@ namespace PropertyExplorerTest.Behaviors
 
             private void Element_LostMouseCapture(object sender, MouseEventArgs e)
             {
-                
+                if (!(e is MouseButtonEventArgs mouseArg))
+                {
+                    return;
+                }
+
+                if (!(sender is FrameworkElement element))
+                {
+                    return;
+                }
+
+                if (object.ReferenceEquals(element, this._element) == false)
+                {
+                    if (this._isZTop)
+                        this.SetZLevelRevert();
+                    return;
+                }
+
+                //InCanvasMovingBehavior.SetZLevel(this._element, this.GetZIndex(element) - 100);
             }
 
             private void OnMouseLeftButtonDown(object sender, RoutedEventArgs e)
@@ -178,8 +334,11 @@ namespace PropertyExplorerTest.Behaviors
                     return;
                 }
 
-                if (object.ReferenceEquals(element, this._element) == false)                
-                { 
+                if (object.ReferenceEquals(element, this._element) == false) 
+                {
+                    if (this._isZTop)
+                        this.SetZLevelRevert();
+
                     return;
                 }
 
@@ -188,12 +347,52 @@ namespace PropertyExplorerTest.Behaviors
                 this._originPoint = mouseArg.GetPosition(this._parent);
 
                 var (left, top) = this.GetElementPosition(element);
+
+                if (!this._isZTop)
+                    this.SetTopLevel(this._element);
+
+                //var z = this.GetZIndex(element);
                 this._originPoint.X -= left;
                 this._originPoint.Y -= top;
+                
+                //Temporally Set Z index to Highest Layer
+                //this._parent.
 
                 element.CaptureMouse();
 
                 Debug.WriteLine($"[shwlee] 1111~~~~~~~~~~~~ element:{this._element.GetHashCode()}, IsCaptured:{this._isCaptured}, Mosue:{this._element.IsMouseCaptured}");
+            }
+
+            private void SetZLevelRevert()
+            {
+                InCanvasMovingBehavior.SetZLevel(this._element, this._savedZLevel);
+
+                this._isZTop = false;
+            }
+
+            private void SetTopLevel(FrameworkElement element)
+            {
+                this._savedZLevel = this.GetZIndex(element);
+
+                //Init Setting For ZLevel AttachedProperty
+                InCanvasMovingBehavior.SetZLevel(this._element, MAX_LEVEL);
+                
+
+                this._isZTop = true;
+            }
+
+            /// <summary>
+            /// ZIndex 가져와서 _savedZLevel에 저장
+            /// </summary>
+            /// <param name="element"></param>
+            /// <returns></returns>
+            private int GetZIndex(FrameworkElement element)
+            {
+                this._savedZLevel = Canvas.GetZIndex(element);
+                //Canvas.SetZIndex(element);
+                this._savedZLevel = this._savedZLevel == 0 ? 0 : this._savedZLevel;
+
+                return this._savedZLevel;
             }
 
             //private void ElementOnMouseDown(object sender, MouseButtonEventArgs e)
@@ -221,6 +420,8 @@ namespace PropertyExplorerTest.Behaviors
                 left = left == double.NaN ? 0 : left;
                 var top = Canvas.GetTop(element);
                 top = top == double.NaN ? 0 : top;
+
+                
 
                 return (left, top);
             }
@@ -256,5 +457,7 @@ namespace PropertyExplorerTest.Behaviors
                 element.ReleaseMouseCapture();
             }
         }
+
+        
     }
 }

--- a/PropertyExplorerTest/Controls/InCanvasMovingBehavior.cs
+++ b/PropertyExplorerTest/Controls/InCanvasMovingBehavior.cs
@@ -268,6 +268,8 @@ namespace PropertyExplorerTest.Behaviors
 
             private bool _isZTop = false;
 
+            private bool _isOnCavasClicked = false;
+
             private int _savedZLevel;
 
             private const int MAX_LEVEL = 255;
@@ -292,12 +294,44 @@ namespace PropertyExplorerTest.Behaviors
                     return;
                 }
 
+
+                EventManager.RegisterClassHandler(typeof(ListBox), ListBox.MouseLeftButtonDownEvent, new RoutedEventHandler(CanvasMouseButtonDown));
+
+                EventManager.RegisterClassHandler(typeof(ListBox), ListBox.MouseLeftButtonUpEvent, new RoutedEventHandler(CanvasMouseButtonUp));
+
+                EventManager.RegisterClassHandler(typeof(ListBox), ListBox.MouseRightButtonDownEvent, new RoutedEventHandler(CanvasMouseButtonDown));
+
+                EventManager.RegisterClassHandler(typeof(ListBox), ListBox.MouseRightButtonUpEvent, new RoutedEventHandler(CanvasMouseButtonUp));
+
+
+
+
                 EventManager.RegisterClassHandler(typeof(ListBoxItem), ListBoxItem.MouseLeftButtonDownEvent, new RoutedEventHandler(this.OnMouseLeftButtonDown));
+
+                EventManager.RegisterClassHandler(typeof(ListBoxItem), ListBoxItem.MouseRightButtonDownEvent, new RoutedEventHandler(this.OnMouseLeftButtonDown));
+
+
 
                 //element.MouseDown += this.ElementOnMouseDown;
                 element.MouseMove += this.ElementOnMouseMove;
                 element.MouseUp += this.ElementOnMouseUp;
                 element.LostMouseCapture += Element_LostMouseCapture;
+            }
+
+            private void CanvasMouseButtonDown(object sender, RoutedEventArgs e)
+            {
+                _isOnCavasClicked = true;
+            }
+
+            private void CanvasMouseButtonUp(object sender, RoutedEventArgs e)
+            {
+                if (_isOnCavasClicked)
+                {
+                    var sv = sender as ListBox;
+                    sv.UnselectAll();
+                    _isOnCavasClicked = false;
+                }
+                
             }
 
             private void Element_LostMouseCapture(object sender, MouseEventArgs e)
@@ -314,8 +348,7 @@ namespace PropertyExplorerTest.Behaviors
 
                 if (object.ReferenceEquals(element, this._element) == false)
                 {
-                    if (this._isZTop)
-                        this.SetZLevelRevert();
+                    
                     return;
                 }
 
@@ -336,9 +369,6 @@ namespace PropertyExplorerTest.Behaviors
 
                 if (object.ReferenceEquals(element, this._element) == false) 
                 {
-                    if (this._isZTop)
-                        this.SetZLevelRevert();
-
                     return;
                 }
 
@@ -388,11 +418,12 @@ namespace PropertyExplorerTest.Behaviors
             /// <returns></returns>
             private int GetZIndex(FrameworkElement element)
             {
-                this._savedZLevel = Canvas.GetZIndex(element);
+                var z = Panel.GetZIndex(element);
+                //var z = Canvas.GetZIndex(element);
                 //Canvas.SetZIndex(element);
-                this._savedZLevel = this._savedZLevel == 0 ? 0 : this._savedZLevel;
+                z = z == 0 ? 0 : z;
 
-                return this._savedZLevel;
+                return z;
             }
 
             //private void ElementOnMouseDown(object sender, MouseButtonEventArgs e)
@@ -451,6 +482,9 @@ namespace PropertyExplorerTest.Behaviors
                 {
                     return;
                 }
+
+                if (this._isZTop)
+                    this.SetZLevelRevert();
 
                 this._isCaptured = false;
 

--- a/PropertyExplorerTest/MainWindow.xaml
+++ b/PropertyExplorerTest/MainWindow.xaml
@@ -7,13 +7,14 @@
     xmlns:local="clr-namespace:PropertyExplorerTest"
     xmlns:views="clr-namespace:PropertyExplorerTest.Views"
     xmlns:control="clr-namespace:PropertyExplorerTest.Controls"
+    xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
     mc:Ignorable="d"
     Title="MainWindow"
     Height="800"
     Width="1225"
     >
     <Grid x:Name="RootContainer">
-        <ScrollViewer>
+        <ScrollViewer x:Name="SV">
             <views:MainContainer />
         </ScrollViewer>
     </Grid>

--- a/PropertyExplorerTest/PropertyExplorerTest.csproj
+++ b/PropertyExplorerTest/PropertyExplorerTest.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Models\PropertyModels\PropertySetExtension.cs" />
     <Compile Include="Models\PropertyModels\PropertySets.cs" />
     <Compile Include="Models\RectModel.cs" />
+    <Compile Include="ViewModels\Commands\SelectItemCommand.cs" />
     <Compile Include="ViewModels\Shapes\BaseShapeViewModel.cs" />
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="ViewModels\Shapes\EllipseViewModel.cs" />

--- a/PropertyExplorerTest/PropertyExplorerTest.csproj
+++ b/PropertyExplorerTest/PropertyExplorerTest.csproj
@@ -56,7 +56,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
-    <Compile Include="Behaviors\InCanvasMovingBehavior.cs" />
+    <Compile Include="Controls\InCanvasMovingBehavior.cs" />
     <Compile Include="Controls\DisplayPresenter.cs" />
     <Compile Include="Controls\MoveThumb.cs" />
     <Compile Include="Converters\BooleanToVisibilityConverter.cs" />
@@ -170,6 +170,9 @@
     <PackageReference Include="System.Windows.Interactivity.WPF">
       <Version>2.0.20525</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Behaviors\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PropertyExplorerTest/Resources/Mapping.Display.xaml
+++ b/PropertyExplorerTest/Resources/Mapping.Display.xaml
@@ -20,6 +20,7 @@
     <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:ColorToSolidBrushConverter x:Key="BrushConverter" />
 
+    <!--Content에 해당하는 영역 in Generic-->
     <DataTemplate DataType="{x:Type shapes:RectViewModel}">
         <control:DisplayPresenter
             X="{Binding X.Value}"

--- a/PropertyExplorerTest/Resources/Styles.xaml
+++ b/PropertyExplorerTest/Resources/Styles.xaml
@@ -20,6 +20,20 @@
     <Color x:Key="BorderLightColor">#FFCCCCCC</Color>
     <Color x:Key="BorderDarkColor">#FF444444</Color>
 
+
+    <Storyboard x:Key="MenuOpen">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Width)" Storyboard.TargetName="GridMenu">
+            <EasingDoubleKeyFrame KeyTime="0" Value="60"/>
+            <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="200"/>
+        </DoubleAnimationUsingKeyFrames>
+    </Storyboard>
+    <Storyboard x:Key="MenuClose">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Width)" Storyboard.TargetName="GridMenu">
+            <EasingDoubleKeyFrame KeyTime="0" Value="200"/>
+            <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="60"/>
+        </DoubleAnimationUsingKeyFrames>
+    </Storyboard>
+
     <!-- 순수하게 스타일적인 요소만 바인딩 되어있고, 데이터 관련 바인딩은 모두 배제되어있다. -->
     <Style x:Key="SelectorStyle" TargetType="{x:Type CheckBox}">
         <Setter Property="SnapsToDevicePixels" Value="true" />

--- a/PropertyExplorerTest/Themes/Generic.xaml
+++ b/PropertyExplorerTest/Themes/Generic.xaml
@@ -7,17 +7,18 @@
 
 
     <Style TargetType="{x:Type control:DisplayPresenter}">
+        
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type control:DisplayPresenter}">
-                    <Border>
+                    <Border x:Name="Border">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="SelectionStates">
+                                <VisualState x:Name="Unselected"/>
+
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                         <Grid>
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroup x:Name="SelectionStates">
-                                    <VisualState x:Name="Unselected"/>
-                                    
-                                </VisualStateGroup>
-                            </VisualStateManager.VisualStateGroups>
 
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="30" />
@@ -27,7 +28,9 @@
 
                             <Grid Grid.Row="0">
                                 <Label
-                                    Content="{Binding Path=Label, RelativeSource={RelativeSource AncestorType={x:Type control:DisplayPresenter}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    Content="{Binding Path=Label, 
+                                    RelativeSource={RelativeSource AncestorType={x:Type control:DisplayPresenter}}, 
+                                    Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     Foreground="White"
                                     FontSize="15"
                                     FontWeight="Bold"

--- a/PropertyExplorerTest/Themes/Generic.xaml
+++ b/PropertyExplorerTest/Themes/Generic.xaml
@@ -12,6 +12,13 @@
                 <ControlTemplate TargetType="{x:Type control:DisplayPresenter}">
                     <Border>
                         <Grid>
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="SelectionStates">
+                                    <VisualState x:Name="Unselected"/>
+                                    
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="30" />
                                 <RowDefinition />

--- a/PropertyExplorerTest/ViewModels/Commands/SelectItemCommand.cs
+++ b/PropertyExplorerTest/ViewModels/Commands/SelectItemCommand.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PropertyExplorerTest.ViewModels.Commands
+{
+    public class SelectItemCommand<IPropertyOperative> : ICommand
+    {
+
+        MainContainerViewModel VM;
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        public SelectItemCommand(MainContainerViewModel vm)
+        {
+            VM = vm;
+        }
+        
+
+        public bool CanExecute(object parameter)
+        {
+            if (parameter != null)
+                return true;
+            else
+                return false;
+        }
+
+        public void Execute(object parameter)
+        {
+            //IPropertyOperative param = parameter as IPropertyOperative;
+            VM.SelectModel((Defines.Interfaces.IPropertyOperative)parameter);
+        }
+    }
+}

--- a/PropertyExplorerTest/ViewModels/MainContainerViewModel.cs
+++ b/PropertyExplorerTest/ViewModels/MainContainerViewModel.cs
@@ -1,14 +1,17 @@
 ﻿using GalaSoft.MvvmLight.Command;
 using PropertyExplorerTest.Defines.Interfaces;
 using PropertyExplorerTest.Models;
+using PropertyExplorerTest.ViewModels.Commands;
 using PropertyExplorerTest.ViewModels.Shapes;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace PropertyExplorerTest.ViewModels
@@ -22,9 +25,17 @@ namespace PropertyExplorerTest.ViewModels
         /// Model선택을 위한 RelayCommand 변수이며 타입은 IPropertyOperative
         /// 인터페이스 타입을 받는다.
         /// </summary>
-        private RelayCommand<IPropertyOperative> _selectModelCommand;
+        //private RelayCommand<IPropertyOperative> _selectModelCommand;
+
+        /// <summary>
+        /// 바인딩된 Command를 통해 SelectModelCommand가 수행되면 아래
+        /// Command Method가 수행되고 Callback Method인 SelectModel이 수행된다.
+        /// </summary>
+        public ICommand SelectModelCommand { get; set; }
         
-        private BaseShapeViewModel _selectedShape;        
+
+        //public SelectItemCommand<IPropertyOperative> SelectModelCommand { get; set; }
+
 
         /// <summary>
         /// ItemControl의 ItemSource로 활용되는 ObservableCollection 변수이다.
@@ -32,22 +43,20 @@ namespace PropertyExplorerTest.ViewModels
         /// </summary>
         public ObservableCollection<BaseShapeViewModel> Items { get; } = new ObservableCollection<BaseShapeViewModel>();
 
+        private BaseShapeViewModel _selectedShape;
+
         public BaseShapeViewModel SelectedShape
         {
             get => _selectedShape;
             set
             {
                 this.SetProperty(ref this._selectedShape, value);
-                this.SelectModel(this._selectedShape);
+                Debug.WriteLine($"SelectedShape: {_selectedShape}");
+                //this.SelectModel(this._selectedShape);
             }
-        }     
+        }
 
-        /// <summary>
-        /// 바인딩된 Command를 통해 SelectModelCommand가 수행되면 아래
-        /// Command Method가 수행되고 Callback Method인 SelectModel이 수행된다.
-        /// </summary>
-        public ICommand SelectModelCommand =>
-              this._selectModelCommand ?? (this._selectModelCommand = new RelayCommand<IPropertyOperative>(this.SelectModel));
+        //this._selectModelCommand ?? (this._selectModelCommand = new RelayCommand<IPropertyOperative>(this.SelectModel));
 
         /// <summary>
         /// PropertyExplorer 인스턴스 생성 및 초기화
@@ -70,6 +79,10 @@ namespace PropertyExplorerTest.ViewModels
         /// </summary>
         public MainContainerViewModel()
         {
+            //SelectModelCommand = this._selectModelCommand ?? (this._selectModelCommand = new RelayCommand<IPropertyOperative>(this.SelectModel));
+            SelectModelCommand = new RelayCommand<IPropertyOperative>(this.SelectModel, canExecute);
+            //SelectModelCommand = new SelectItemCommand<IPropertyOperative>(this);
+
             Random rand = new Random();
             var min = 1;
             var max = 600;
@@ -79,16 +92,27 @@ namespace PropertyExplorerTest.ViewModels
             this.Items.Add(new RectViewModel(rectModel));
             this.Items.Add(new EllipseViewModel(ellipseModel));
             this.Items.Add(new LineViewModel(lineModel));
+
+        }
+        
+        private bool canExecute(IPropertyOperative arg)
+        {
+            if (arg != null)
+                return true;
+            else
+                return false;
         }
 
+                
         /// <summary>
         /// Model 선택에 따른 해당 모델에 설정된 속성 정보를 
         /// Property를 PropertyChange를 위한 목록에 등록하는 과정
         /// </summary>
         /// <param name="model"></param>
-        private void SelectModel(IPropertyOperative model)
+        public void SelectModel(IPropertyOperative model)
         {
-            this.PropertyExplorer.SelectModel(model);
+            if(model != null)
+                this.PropertyExplorer.SelectModel(model);
         }
     }
 }

--- a/PropertyExplorerTest/ViewModels/Shapes/BaseShapeViewModel.cs
+++ b/PropertyExplorerTest/ViewModels/Shapes/BaseShapeViewModel.cs
@@ -107,7 +107,7 @@ namespace PropertyExplorerTest.ViewModels.Shapes
             var location = new PropertyCategory("Location");
             location.Properties.Add(new PropertyContainer(this.X, location));
             location.Properties.Add(new PropertyContainer(this.Y, location));
-            size.Properties.Add(new PropertyContainer(this.ZLevel, size));
+            size.Properties.Add(new PropertyContainer(this.ZLevel, location));
             this._categories.Add(location);
 
             var color = new PropertyCategory("Color");

--- a/PropertyExplorerTest/Views/MainContainer.xaml
+++ b/PropertyExplorerTest/Views/MainContainer.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:behaviors="clr-namespace:PropertyExplorerTest.Behaviors"
     xmlns:viewModels="clr-namespace:PropertyExplorerTest.ViewModels"
+    xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
     mc:Ignorable="d"
     d:DesignHeight="850"
     d:DesignWidth="1200"
@@ -42,19 +43,23 @@
                     Background="Transparent"
                     ItemsSource="{Binding Items}"
                     SelectionMode="Extended"
-                    SelectedItem="{Binding SelectedShape}"
+                    SelectedItem="{Binding SelectedShape, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     Margin="5"
-                    PreviewMouseLeftButtonDown="CanvasListBox_PreviewMouseLeftButtonDown"
                     >
+                    
+                    <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem x:Name="Property" Header="Property" Command="{Binding SelectModelCommand}" 
+                                      CommandParameter="{Binding SelectedShape}"/>
+                        </ContextMenu>
+                    </ListBox.ContextMenu>
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
-
                             <Canvas
                                 ClipToBounds="True"
                                 SnapsToDevicePixels="True"
                                 Margin="5" 
                                 >
-                                
                             </Canvas>
                         </ItemsPanelTemplate>
                         
@@ -70,6 +75,7 @@
                             <Setter Property="behaviors:InCanvasMovingBehavior.ZLevel" Value="{Binding ZLevel.Value}" />
                             <Setter Property="behaviors:InCanvasMovingBehavior.Captured" Value="{Binding IsSelected, RelativeSource={RelativeSource Self}}" />
                         </Style>
+                        
                     </ItemsControl.ItemContainerStyle>
                 </ListBox>
             </Border>
@@ -82,8 +88,9 @@
             Background="#FF9C9C9C"
             />
 
-        <Grid Grid.Column="1">
+        <Grid Grid.Column="1" x:Name="PropertyWindow">
             <ContentControl Content="{Binding PropertyExplorer}" />
+            
         </Grid>
     </Grid>
 </UserControl>

--- a/PropertyExplorerTest/Views/MainContainer.xaml
+++ b/PropertyExplorerTest/Views/MainContainer.xaml
@@ -38,21 +38,26 @@
                 Width="1024"
                 Height="768"
                 >
-                <ListBox
+                <ListBox x:Name ="CanvasListBox"
                     Background="Transparent"
                     ItemsSource="{Binding Items}"
                     SelectionMode="Extended"
                     SelectedItem="{Binding SelectedShape}"
                     Margin="5"
+                    PreviewMouseLeftButtonDown="CanvasListBox_PreviewMouseLeftButtonDown"
                     >
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
+
                             <Canvas
                                 ClipToBounds="True"
                                 SnapsToDevicePixels="True"
-                                Margin="5"
-                                />
+                                Margin="5" 
+                                >
+                                
+                            </Canvas>
                         </ItemsPanelTemplate>
+                        
                     </ListBox.ItemsPanel>
                     <ItemsControl.ItemContainerStyle>
                         <Style TargetType="{x:Type ListBoxItem}">
@@ -62,6 +67,7 @@
                             <Setter Property="behaviors:InCanvasMovingBehavior.PanningTarget" Value="{Binding RelativeSource={RelativeSource Self}}" />
                             <Setter Property="behaviors:InCanvasMovingBehavior.X" Value="{Binding X.Value}" />
                             <Setter Property="behaviors:InCanvasMovingBehavior.Y" Value="{Binding Y.Value}" />
+                            <Setter Property="behaviors:InCanvasMovingBehavior.ZLevel" Value="{Binding ZLevel.Value}" />
                             <Setter Property="behaviors:InCanvasMovingBehavior.Captured" Value="{Binding IsSelected, RelativeSource={RelativeSource Self}}" />
                         </Style>
                     </ItemsControl.ItemContainerStyle>

--- a/PropertyExplorerTest/Views/MainContainer.xaml.cs
+++ b/PropertyExplorerTest/Views/MainContainer.xaml.cs
@@ -25,17 +25,6 @@ namespace PropertyExplorerTest.Views
             InitializeComponent();
         }
 
-        /// <summary>
-        /// MVVM 패턴으로 구현하려면 어떻게 접근해야될까요?
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void CanvasListBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-        {
-            if (!(e.OriginalSource is ScrollViewer viewer))
-                return;
-
-            CanvasListBox.UnselectAll();
-        }
+        
     }
 }

--- a/PropertyExplorerTest/Views/MainContainer.xaml.cs
+++ b/PropertyExplorerTest/Views/MainContainer.xaml.cs
@@ -24,5 +24,18 @@ namespace PropertyExplorerTest.Views
         {
             InitializeComponent();
         }
+
+        /// <summary>
+        /// MVVM 패턴으로 구현하려면 어떻게 접근해야될까요?
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void CanvasListBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!(e.OriginalSource is ScrollViewer viewer))
+                return;
+
+            CanvasListBox.UnselectAll();
+        }
     }
 }


### PR DESCRIPTION
쉬시는 날에 문의드립니다.

아마 주말에 쉬셔서 답변 없으실 것 같지만,, 어제오늘 계속 고민해보고 잘 이해가 안되는 부분을 올려봅니다.

1. `public class PanningStructure : DependencyObject` 을 따로 선언해서 사용하시는 이유는 무엇일까요?
분석해보니까, `public class InCanvasMovingBehavior : DependencyObject` 여기 등록된 inner class고
주로 기능적인 측면을 담당하는 클래스 같았습니다.

1)  들어오는 ViewModel에 따른 PanningStructure를 생성하고, InCavasMovingBehavior 단에는 Xaml에 연동할 AP쪽을 
세팅하는 역할을 하는 것 같앗습니다.
혹시, 이렇게 구현하신 이유는 무엇인지 알수 있을까요? 제가 ZLevel을 AP로 따로 구현해서 캔버스위의 오브젝트를 클릭하면
최상단으로 오는 로직은 구현을 했는데요. 정작 Property에서 기존의 저장된 BaseModel에 저장된 ZLevel의 값도 같이 변하고 다른것으로 연동해 놓으니까 ZLevel의 Property가 의미가 없어진 상황입니다. ㅎㅎ

그래서 생각을 해봤습니다. 평소에는 PropertyExplorer 창이 안나타나다가, 캔버스 위에 Rectangle 혹은 Ellipse 등 오른쪽 마우스 버튼을 누르면 메뉴가 나오고 메뉴를 클릭하면 창이 나타나는 구조를 구현하는 것 가능할까요?

한개 한개 구현하는 게 진짜 너무 어렵네요...ㅠㅠ

2. 캔버스를 클릭하면 선택된 ListBoxItem이 전체 UnSelected 형태로 만드려면 어디에 Command를 넣어주면 될까요?
 RoutedCommand를 통해서 `myListBox.UnselectAll();` 해주려고 하는데요. 아무래도 Scrollviewer에 걸리는데 어떻게 MVVM으로 처리해주면 좋을까요?

제가 일단 작업한 부분을 PR로  보내드립니다.

혹시 시간되시면 확인 부탁드립니다.

항상 감사드리며, 편안한 연휴 되세요~